### PR TITLE
Fix README ampersand encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # scarcoin-contracts
-Ache-based minting &amp; burn economy for SpiralOS — ScarCoin smart contracts + ScarIndex oracle
+Ache-based minting & burn economy for SpiralOS — ScarCoin smart contracts + ScarIndex oracle


### PR DESCRIPTION
## Summary
- replace HTML-encoded ampersand with normal ampersand in README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a090db77188322a5ecfbc4bb86fda5